### PR TITLE
refactor: remove partitioning from gold models

### DIFF
--- a/dbt/Threelacha/models/gold/api10_price_comparison.sql
+++ b/dbt/Threelacha/models/gold/api10_price_comparison.sql
@@ -1,8 +1,7 @@
 {{ config(
     materialized='table',
     format='PARQUET',
-    location='s3://team3-batch/gold/api10_price_comparison/',
-    partitioned_by=['dt']
+    location='s3://team3-batch/gold/api10_price_comparison/'
 ) }}
 
 SELECT

--- a/dbt/Threelacha/models/gold/api13_price_statistics_by_category.sql
+++ b/dbt/Threelacha/models/gold/api13_price_statistics_by_category.sql
@@ -2,8 +2,7 @@
     materialized='table',
     file_format='parquet',
     write_compression='snappy',
-    location='s3://team3-batch/gold/api13_price_statistics_by_category/',
-    partitioned_by=['year', 'month']
+    location='s3://team3-batch/gold/api13_price_statistics_by_category/'
 ) }}
 
 SELECT 


### PR DESCRIPTION
## ✨ What
- gold dbt 모델에서 파티셔닝 제거

## 🎯 Why
- s3에 저장된 gold 단은 rds로 동기화 예정
- s3 → rds 동기화 시, COPY 명령어 사용을 위한 구조변경
- streamlit 역시 rds에 연결 예정이기에, gold 단의 파티셔닝 불필요

## 📌 Changes
- 파이셔닝 제거

## 🧪 Test
- 운영에서 구동 후, S3 결과 확인 예정