### PR TITLE
chore: optimize dbt container resources and boot stability

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -354,10 +354,17 @@ services:
     build: ./dbt
     platform: linux/amd64
     container_name: dbt
+    restart: unless-stopped
     volumes:
       - ./dbt:/usr/app
       - ./dbt/logs:/usr/app/logs
       - ./dbt/target:/usr/app/target
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+        reservations:
+          memory: 256M
     working_dir: /usr/app
     environment:
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}


### PR DESCRIPTION
## ✨ What
- dbt 구동 안정화 위한 compoe 파일 수정

## 🎯 Why
- 오전 9시에 ec2 재시작 시, dbt 컨테이너 137 종료코드로 종료된 상태 반복적으로 확인
- 137 종료코드는 OOM의미
- 이에 안정적인 구동을 위해 dbt 구동 환경 안정화

## 📌 Changes
- 재시작 정책 부여 : unless-stopped
- 메모리 제한 부여 : 768M